### PR TITLE
Bugfix 'No rust' minimod

### DIFF
--- a/No_rust/modinfo.json
+++ b/No_rust/modinfo.json
@@ -42,7 +42,7 @@
     "player_display": false,
     "enchantments": [
       {
-        "condition": "ALLWAYS",
+        "condition": "ALWAYS",
         "values": [ { "value": "SKILL_RUST_RESIST", "multiply": -100.0 }, { "value": "SKILL_RUST_RESIST", "add": 10000 } ]
       }
     ],


### PR DESCRIPTION
### Summary
Fixed typo that prevented the 'No Rust' minimod from working as intended.

### Testing
Freshly downloaded and unpacked Cataclysm: DDA (experimental 2025-08-17-1653), as well as the [V1.2 No Rust minimod](https://github.com/John-Candlebury/CDDA-Minimods/releases/tag/norustV1.2).
Created a fresh world with default settings and mods and added the 'No Rust' minimod, created a random character, moved to a safe space and saved the game. Then made the character wait for 20 hours and checked skills (they suffered from rust).
Exited the game without saving, replaced the mod file with the one from the fix, restarted the game, reloaded the save and again made the character wait for 20 hours. Checking the skills showed that they didn't degrade this time.

### Additional infos
Since the "Flawless Memory" perk from "Bombastic perks" no longer provide a way to prevent skill degregation, I was quite happy to have found this minimod.
I also think I found a more reliable way to make NPC skills "rust-proof" using the "global" and "run_for_npcs" fields on an event, but I want to test this more and keep it seperate from the bugfix.
Finally I want to appologize to everyone, as I've both realized that this mod doesn't work as intendet and fixed it <ins>**over one and a half years ago**</ins> (in a different version back then), but never made a pull request until I've set up a new system and had to rediscover both that it's broken AND the typo that broke it. Sorry for that mistake.