### PR TITLE
'No rust' minimod - Better NPC handling

### DIFF
--- a/No_rust - Steam 0.G/modinfo.json
+++ b/No_rust - Steam 0.G/modinfo.json
@@ -24,7 +24,7 @@
     "points": 0,
     "//": "We double dip, but maybe there's no need to?",
     "skill_rust_multiplier": 0,
-    "enchantments": [ { "condition": "ALLWAYS", "values": [ { "value": "SKILL_RUST_RESIST", "add": 100000 } ] } ],
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "SKILL_RUST_RESIST", "add": 100000 } ] } ],
     "description": "Disables skill rust."
   }
 ]

--- a/No_rust/modinfo.json
+++ b/No_rust/modinfo.json
@@ -26,12 +26,13 @@
     "effect": [ { "u_add_trait": "NO_SKILL_RUST_TRAIT" } ]
   },
   {
-    "//": "This one is for NPC followers.  There might be a better alternative.",
+    "//": "This one is for NPC followers.",
     "type": "effect_on_condition",
     "id": "EOC_REMOVE_SKILL_RUST_ON_KILL",
-    "eoc_type": "EVENT",
-    "required_event": "character_kills_monster",
+    "eoc_type": "RECURRING",
+    "recurrence": 900,
     "condition": { "not": { "u_has_trait": "NO_SKILL_RUST_TRAIT" } },
+    "deactivate_condition": { "u_has_trait": "NO_SKILL_RUST_TRAIT" },
     "effect": [ { "u_add_trait": "NO_SKILL_RUST_TRAIT" } ]
   },
   {
@@ -40,6 +41,7 @@
     "name": { "str": "no skill rust" },
     "points": 0,
     "player_display": false,
+    "purifiable": false,
     "enchantments": [
       {
         "condition": "ALWAYS",


### PR DESCRIPTION
### Summary
Changed the way the mod applies the 'No rust' trait to NPCs. Now they will get the trait exactly 15 minutes (and 1 second) after they spawn in, even if they don't kill anything (which might be the case if you recruit them near your basecamp or in a cleared environment).
Made the trait resist purifiers.
Bugfix to the 0.G Steam version, as it also had the "ALLWAYS" typo.

### Testing
Tested against Cataclysm: DDA Experimental version 2025-08-17-1653.
Spawned into an existing world with the mod retroactively added to the (unmodified) default mod list. Character had the trait immediately on load, NPCs 15 minutes and 1 second later.
Created new world with default mod list + 'No Rust' mod. Same result as above.
Spawned in an NPC, waited 5 minutes and spawned in another one. NPC 1 got the trait after exactly 10 more minutes + 1 sec, NPC 2 didn't get the trait until exactly 5 more minutes have passed.

### Additional infos
I didn't have the time to check the base C++ code for this, but based on the tests done, it seems like the "recurrence" EOC is added to each character once it spawns in the game and de-/reactivates as described [in the docs](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/JSON/EFFECT_ON_CONDITION.md#fields), meaning it will not take up resources to check all NPCs and player character every 15 minutes for the trait, making it probably the most efficient choice. It might be even safe to set the recurrence timer to 1, but I didn't want to risk that many checks if I'm wrong.
This comes with a "downside", however: You can't remove the trait from yourself or an NPC permanently, as it will just add it back after 15 minutes.
I've experimented with other ways to add the trait; having `"global": true, "run_for_npcs": true` tagged on an event like the already used `"required_event": "game_load"` (line 20-27) _will_ work, but - of course - only on game load. Depending on game session length, some NPCs might suffer extended skill loss. Adding this to other events would make it either run too often (`"character_starts_activity"` | `"character_gains_effect"` | `"avatar_moves"`), especially if you've got a lot of NPCs, or too unpredictable (`"character_wakes_up"` | `"character_kills_monster"` | `"avatar_enters_omt"`) to be of any use (since there's no "npc_spawns" event I'm aware of).
As for the `"purifiable": false`, I'm not sure it actually could be purified... and even if it was, it would retrigger 15 minutes later, so that's not a big deal... but it would "waste" purifier, so I've figured it's a good thing to have.